### PR TITLE
sdm845-common: Pin libsurfaceflinger

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -331,6 +331,7 @@
         <item>"/system/framework/boot.vdex"</item>
         <item>"/system/framework/arm64/boot-core-libart.oat"</item>
         <item>"/system/framework/boot-core-libart.vdex"</item>
+        <item>"/system/lib64/libsurfaceflinger.so"</item>
     </string-array>
 
     <!-- Boolean indicating whether the HWC setColorTransform function can be performed efficiently


### PR DESCRIPTION
* This makes SF more responsive as it gets zram'ed in certain cases
* This only takes 2-3 MB of memory impact

Test: SF is more responsive and no janks